### PR TITLE
Add ES6 example to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ First declare `express-html-validator` as a dependency in your app.
 
 Then require the package into your application and call its constructor, passing along your Express app:
 
-For usage with CommonJS:
+Usage with CommonJS:
 
 ```js
 const express = require('express')

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ First declare `express-html-validator` as a dependency in your app.
 
 Then require the package into your application and call its constructor, passing along your Express app:
 
+For usage with CommonJS:
+
 ```js
 const express = require('express')
 const expressValidator = require('express-html-validator')
@@ -29,6 +31,29 @@ app.get('/', (req, res) => {
 })
 ```
 
+For usage with ES6:
+
+```js
+import express from 'express';
+import expressValidator from 'express-html-validator'
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
+const router = express.Router();
+const app = express()
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// Generally this would be used in development mode
+if (process.env.NODE_ENV === 'development') {
+  expressValidator(app, config)
+}
+
+// expressValidator should be called before defining routes
+router.get('/', (req, res) => {
+  // This html response will be validated in real time as it's sent
+  res.sendFile(__dirname + '/index.html');
+})
+```
 You can also run the validator on arbitrary strings outide of the Express context:
 
 ```js
@@ -80,3 +105,4 @@ Optionally you can pass this module a set of configs:
       "extends": ["html-validate:standard"]
     }
     ```
+    

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ app.get('/', (req, res) => {
 })
 ```
 
-For usage with ES6:
+Usage with ES modules:
 
 ```js
 import express from 'express';

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ router.get('/', (req, res) => {
   res.sendFile(__dirname + '/index.html');
 })
 ```
-You can also run the validator on arbitrary strings outide of the Express context:
+You can also run the validator on arbitrary strings outide of the Express context (example in CommonJS):
 
 ```js
 const config = {}


### PR DESCRIPTION
Updated the README.md to show how to use express-html-validator in ES6.

#173 